### PR TITLE
feat: add preset metadata structure and detail cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,116 +16,28 @@
 
     <input type="text" id="preset-filter" placeholder="Search presets...">
 
-    <div class="preset-list">
-      <!-- Clean Basic -->
-      <div class="preset card">
-        <h3>Clean Basic</h3>
-        <p>A classic clean tone for chords and arpeggios. Slight compression and a hall reverb keep it smooth without getting muddy.</p>
-        <p><strong>References:</strong></p>
-        <ul class="refs">
-          <li>Pink Floyd</li>
-          <li>Dire Straits</li>
-          <li>The Police</li>
-          <li>Stevie Ray Vaughan</li>
-        </ul>
-        <a class="download-link" href="presets/preset1.json" download>Download preset</a>
-        <img src="qrcodes/preset1.png" alt="QR code for Clean Basic preset">
-      </div>
-
-      <!-- Atmospheric Clean -->
-      <div class="preset card">
-        <h3>Atmospheric Clean</h3>
-        <p>Ambient clean tone with digital delay and shimmer reverb. Perfect for slow intros and spacious soundscapes.</p>
-        <p><strong>References:</strong></p>
-        <ul class="refs">
-          <li>Sigur Rós</li>
-          <li>Explosions in the Sky</li>
-          <li>U2</li>
-          <li>Coldplay</li>
-        </ul>
-        <a class="download-link" href="presets/preset2.json" download>Download preset</a>
-        <img src="qrcodes/preset2.png" alt="QR code for Atmospheric Clean preset">
-      </div>
-
-      <!-- Crunch Universal -->
-      <div class="preset card">
-        <h3>Crunch Universal</h3>
-        <p>Medium‑gain crunch on a Plexi 45. Versatile for rock, punk or blues – responsive to your picking dynamics.</p>
-        <p><strong>References:</strong></p>
-        <ul class="refs">
-          <li>AC/DC</li>
-          <li>Led Zeppelin</li>
-          <li>Foo Fighters</li>
-          <li>Nirvana</li>
-        </ul>
-        <a class="download-link" href="presets/preset3.json" download>Download preset</a>
-        <img src="qrcodes/preset3.png" alt="QR code for Crunch Universal preset">
-      </div>
-
-      <!-- Heavy Rhythm -->
-      <div class="preset card">
-        <h3>Heavy Rhythm – Brit 800</h3>
-        <p>High‑gain rhythm tone based on a Marshall JCM800 with a Tube Screamer push. Tight low end and articulate attack.</p>
-        <p><strong>References:</strong></p>
-        <ul class="refs">
-          <li>Metallica</li>
-          <li>Megadeth</li>
-          <li>Judas Priest</li>
-          <li>Slayer</li>
-        </ul>
-        <a class="download-link" href="presets/preset4.json" download>Download preset</a>
-        <img src="qrcodes/preset4.png" alt="QR code for Heavy Rhythm Brit 800 preset">
-      </div>
-
-      <!-- Metal Lead -->
-      <div class="preset card">
-        <h3>Metal Lead – Brit 800</h3>
-        <p>Lead version of the Brit 800 with extra mids, delay and hall reverb. Designed for soaring solos that cut through the mix.</p>
-        <p><strong>References:</strong></p>
-        <ul class="refs">
-          <li>Iron Maiden</li>
-          <li>Guns N' Roses</li>
-          <li>Dream Theater</li>
-          <li>Metallica</li>
-        </ul>
-        <a class="download-link" href="presets/preset5.json" download>Download preset</a>
-        <img src="qrcodes/preset5.png" alt="QR code for Metal Lead Brit 800 preset">
-      </div>
-
-      <!-- Ambient Clean Mod -->
-      <div class="preset card">
-        <h3>Ambient Clean Mod</h3>
-        <p>Wide clean tone with stereo chorus, delay and shimmer reverb. Great for 80s‑inspired parts and dreamy textures.</p>
-        <p><strong>References:</strong></p>
-        <ul class="refs">
-          <li>The Cure</li>
-          <li>The Police</li>
-          <li>Slowdive</li>
-          <li>Cocteau Twins</li>
-        </ul>
-        <a class="download-link" href="presets/preset6.json" download>Download preset</a>
-        <img src="qrcodes/preset6.png" alt="QR code for Ambient Clean Mod preset">
-      </div>
-
-      <!-- OctaSpace Lead -->
-      <div class="preset card">
-        <h3>OctaSpace Lead</h3>
-        <p>An experimental lead sound with detune, tape echo and shimmer. Ideal for psychedelic, post‑rock and shoegaze.</p>
-        <p><strong>References:</strong></p>
-        <ul class="refs">
-          <li>Radiohead</li>
-          <li>Smashing Pumpkins</li>
-          <li>Tame Impala</li>
-          <li>My Bloody Valentine</li>
-        </ul>
-        <a class="download-link" href="presets/preset7.json" download>Download preset</a>
-        <img src="qrcodes/preset7.png" alt="QR code for OctaSpace Lead preset">
-      </div>
-    </div>
+    <div class="preset-list" id="preset-list"></div>
 
     <p><a class="download-link" href="mailto:1fokingleb@gmail.com">Make me a preset</a></p>
   </main>
+  <script src="presets.js"></script>
   <script>
+    const list = document.getElementById('preset-list');
+    presets.forEach(preset => {
+      const card = document.createElement('div');
+      card.className = 'preset card';
+      card.innerHTML = `
+        <h3>${preset.name}</h3>
+        <p>${preset.description}</p>
+        <p><strong>References:</strong></p>
+        <ul class="refs">${preset.references.map(r => `<li>${r}</li>`).join('')}</ul>
+        <a class="download-link" href="${preset.file}" download>Download preset</a>
+        <a class="download-link" href="preset.html?id=${preset.id}">View settings</a>
+        <img src="${preset.qr}" alt="QR code for ${preset.name} preset">
+      `;
+      list.appendChild(card);
+    });
+
     const filterInput = document.getElementById('preset-filter');
     filterInput.addEventListener('input', () => {
       const query = filterInput.value.toLowerCase();

--- a/preset.html
+++ b/preset.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Preset Details</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main id="preset-detail"></main>
+  <script src="presets.js"></script>
+  <script>
+    const container = document.getElementById('preset-detail');
+    const params = new URLSearchParams(window.location.search);
+    const id = params.get('id');
+    const preset = presets.find(p => p.id === id);
+    if (!preset) {
+      container.textContent = 'Preset not found.';
+    } else {
+      const title = document.createElement('h1');
+      title.textContent = preset.name;
+      container.appendChild(title);
+
+      const desc = document.createElement('p');
+      desc.textContent = preset.description;
+      container.appendChild(desc);
+
+      const refsTitle = document.createElement('p');
+      refsTitle.innerHTML = '<strong>References:</strong>';
+      container.appendChild(refsTitle);
+      const refsList = document.createElement('ul');
+      refsList.className = 'refs';
+      preset.references.forEach(r => {
+        const li = document.createElement('li');
+        li.textContent = r;
+        refsList.appendChild(li);
+      });
+      container.appendChild(refsList);
+
+      fetch(preset.file)
+        .then(res => res.json())
+        .then(data => {
+          const chainDiv = document.createElement('div');
+          chainDiv.className = 'card';
+          const chainTitle = document.createElement('h2');
+          chainTitle.textContent = 'Signal Chain';
+          chainDiv.appendChild(chainTitle);
+
+          data.chain.forEach(slot => {
+            const slotDiv = document.createElement('div');
+            slotDiv.className = 'slot';
+            const slotTitle = document.createElement('h3');
+            slotTitle.textContent = `${slot.slot} – ${slot.model}`;
+            slotDiv.appendChild(slotTitle);
+            const ul = document.createElement('ul');
+            Object.entries(slot.params).forEach(([k, v]) => {
+              const li = document.createElement('li');
+              li.textContent = `${k}: ${v}`;
+              ul.appendChild(li);
+            });
+            slotDiv.appendChild(ul);
+            chainDiv.appendChild(slotDiv);
+          });
+
+          container.appendChild(chainDiv);
+
+          const download = document.createElement('a');
+          download.className = 'download-link';
+          download.href = preset.file;
+          download.download = '';
+          download.textContent = 'Download preset';
+          container.appendChild(download);
+
+          const img = document.createElement('img');
+          img.src = preset.qr;
+          img.alt = `QR code for ${preset.name} preset`;
+          container.appendChild(img);
+        })
+        .catch(() => {
+          const error = document.createElement('p');
+          error.textContent = 'Unable to load preset details.';
+          container.appendChild(error);
+        });
+    }
+  </script>
+</body>
+</html>

--- a/presets.js
+++ b/presets.js
@@ -1,0 +1,62 @@
+const presets = [
+  {
+    id: 'preset1',
+    name: 'Clean Basic',
+    description: 'A classic clean tone for chords and arpeggios. Slight compression and a hall reverb keep it smooth without getting muddy.',
+    references: ['Pink Floyd', 'Dire Straits', 'The Police', 'Stevie Ray Vaughan'],
+    file: 'presets/preset1.json',
+    qr: 'qrcodes/preset1.png'
+  },
+  {
+    id: 'preset2',
+    name: 'Atmospheric Clean',
+    description: 'Ambient clean tone with digital delay and shimmer reverb. Perfect for slow intros and spacious soundscapes.',
+    references: ['Sigur Rós', 'Explosions in the Sky', 'U2', 'Coldplay'],
+    file: 'presets/preset2.json',
+    qr: 'qrcodes/preset2.png'
+  },
+  {
+    id: 'preset3',
+    name: 'Crunch Universal',
+    description: 'Medium‑gain crunch on a Plexi 45. Versatile for rock, punk or blues – responsive to your picking dynamics.',
+    references: ['AC/DC', 'Led Zeppelin', 'Foo Fighters', 'Nirvana'],
+    file: 'presets/preset3.json',
+    qr: 'qrcodes/preset3.png'
+  },
+  {
+    id: 'preset4',
+    name: 'Heavy Rhythm – Brit 800',
+    description: 'High‑gain rhythm tone based on a Marshall JCM800 with a Tube Screamer push. Tight low end and articulate attack.',
+    references: ['Metallica', 'Megadeth', 'Judas Priest', 'Slayer'],
+    file: 'presets/preset4.json',
+    qr: 'qrcodes/preset4.png'
+  },
+  {
+    id: 'preset5',
+    name: 'Metal Lead – Brit 800',
+    description: 'Lead version of the Brit 800 with extra mids, delay and hall reverb. Designed for soaring solos that cut through the mix.',
+    references: ['Iron Maiden', "Guns N'\u00a0Roses", 'Dream Theater', 'Metallica'],
+    file: 'presets/preset5.json',
+    qr: 'qrcodes/preset5.png'
+  },
+  {
+    id: 'preset6',
+    name: 'Ambient Clean Mod',
+    description: 'Wide clean tone with stereo chorus, delay and shimmer reverb. Great for 80s‑inspired parts and dreamy textures.',
+    references: ['The Cure', 'The Police', 'Slowdive', 'Cocteau Twins'],
+    file: 'presets/preset6.json',
+    qr: 'qrcodes/preset6.png'
+  },
+  {
+    id: 'preset7',
+    name: 'OctaSpace Lead',
+    description: 'An experimental lead sound with detune, tape echo and shimmer. Ideal for psychedelic, post‑rock and shoegaze.',
+    references: ['Radiohead', 'Smashing Pumpkins', 'Tame Impala', 'My Bloody Valentine'],
+    file: 'presets/preset7.json',
+    qr: 'qrcodes/preset7.png'
+  }
+];
+
+if (typeof module !== 'undefined') {
+  module.exports = { presets };
+}

--- a/style.css
+++ b/style.css
@@ -81,3 +81,13 @@ a.download-link:hover {
   margin: 20px 0;
   box-sizing: border-box;
 }
+
+.slot {
+  margin-bottom: 10px;
+}
+
+.slot ul {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}


### PR DESCRIPTION
## Summary
- centralize preset metadata in `presets.js` for easy additions
- generate preset cards from data and link to new `preset.html` detail view
- show full signal chain settings in preset detail pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895aff7361c832aa3234fc8404592f6