### PR TITLE
Add navigation header and make preset cards clickable

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -9,6 +9,10 @@ on:
   push:
     branches: ["main"]
 
+  # Deploy preview on pull requests
+  pull_request:
+    branches: ["main"]
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/components/Header.js
+++ b/components/Header.js
@@ -1,0 +1,13 @@
+import Link from 'next/link';
+
+export default function Header() {
+  return (
+    <header className="bg-gray-100 p-4 mb-4">
+      <nav className="container mx-auto">
+        <Link href="/" className="text-xl font-bold">
+          MightyPatch
+        </Link>
+      </nav>
+    </header>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,18 +1,26 @@
 import Link from 'next/link';
+import Header from '../components/Header';
 import { presets } from '../data/presets';
 
 export default function Home({ presets }) {
   return (
     <div className="min-h-screen p-4">
+      <Header />
       <h1 className="text-2xl font-bold mb-4">Preset Library</h1>
       <ul className="grid gap-4 md:grid-cols-2">
         {presets.map((preset) => (
-          <li key={preset.id} className="border p-4 rounded shadow">
-            <h2 className="text-xl font-semibold mb-2">{preset.name}</h2>
-            <p className="mb-2">{preset.description}</p>
-            <img src={preset.qr} alt={`${preset.name} QR`} className="w-24 h-24 mb-2" />
-            <Link href={`/preset/${preset.id}`} className="text-blue-600 underline">
-              View settings
+          <li key={preset.id}>
+            <Link
+              href={`/preset/${preset.id}`}
+              className="block border p-4 rounded shadow hover:bg-gray-50"
+            >
+              <h2 className="text-xl font-semibold mb-2">{preset.name}</h2>
+              <p className="mb-2">{preset.description}</p>
+              <img
+                src={preset.qr}
+                alt={`${preset.name} QR`}
+                className="w-24 h-24"
+              />
             </Link>
           </li>
         ))}

--- a/pages/preset/[id].js
+++ b/pages/preset/[id].js
@@ -1,12 +1,12 @@
 import fs from 'fs';
 import path from 'path';
-import Link from 'next/link';
+import Header from '../../components/Header';
 import { presets } from '../../data/presets';
 
 export default function PresetPage({ preset, data }) {
   return (
     <div className="min-h-screen p-4">
-      <Link href="/" className="text-blue-600 underline">← Back</Link>
+      <Header />
       <h1 className="text-2xl font-bold mb-2">{preset.name}</h1>
       <p className="mb-4">{preset.description}</p>
       <h2 className="text-xl font-semibold mb-2">Signal chain</h2>
@@ -22,9 +22,6 @@ export default function PresetPage({ preset, data }) {
           </li>
         ))}
       </ol>
-      <a href={`/${preset.file}`} className="text-blue-600 underline" download>
-        Download JSON
-      </a>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add shared navigation header branded as MightyPatch
- make preset cards link directly to their details
- simplify preset pages by removing back and download links
- deploy preview builds to GitHub Pages for pull requests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895c4e66f18832a82b750bf605a6d21