### PR TITLE
Refine knob labels and EQ display

### DIFF
--- a/components/Knob.js
+++ b/components/Knob.js
@@ -23,7 +23,9 @@ export default function Knob({ label, value, color = '#ef4444' }) {
         />
       </div>
       <span className="mt-2 text-xs text-gray-200 text-center">
-        {label}: {value}
+        {label}
+        <br />
+        {value}
       </span>
     </div>
   );

--- a/pages/preset/[id].js
+++ b/pages/preset/[id].js
@@ -26,7 +26,7 @@ function formatLabel(key) {
     .replace(/_/g, ' ');
 }
 
-function EqDisplay({ params }) {
+function EqDisplay({ params, color = '#9ca3af' }) {
   const freqs = Object.keys(params);
   const [levels, setLevels] = useState(
     freqs.reduce((acc, f) => ({ ...acc, [f]: 50 }), {})
@@ -41,25 +41,22 @@ function EqDisplay({ params }) {
     <div className="flex items-center h-32 space-x-3 p-4 bg-gray-900 rounded-lg border border-gray-700">
       {freqs.map((freq) => {
         const val = Number(levels[freq]);
-        const pos = Math.max(0, val - 50) * 2;
-        const neg = Math.max(0, 50 - val) * 2;
-        const display = Number(params[freq]) - 50;
+        const display = ((Number(params[freq]) - 50) / 50) * 15;
         return (
           <div key={freq} className="flex flex-col items-center">
             <span className="mb-1 text-xs text-gray-200">
               {display >= 0 ? '+' : ''}
-              {display}
+              {display.toFixed(1)} dB
             </span>
-            <div className="relative w-4 h-28 bg-gray-800 rounded overflow-hidden group">
+            <div className="relative w-4 h-28 bg-gray-800 rounded overflow-hidden">
               <div
-                className="absolute bottom-1/2 w-full bg-gradient-to-t from-red-600 via-pink-500 to-yellow-300 transition-all duration-700 ease-out shadow-[0_0_8px_rgba(255,255,255,0.7)] group-hover:animate-eqGlow"
-                style={{ height: `${pos}%` }}
+                className="absolute left-0 w-full h-0.5"
+                style={{ top: `${100 - val}%`, backgroundColor: color }}
               />
               <div
-                className="absolute top-1/2 w-full bg-gradient-to-b from-red-600 via-pink-500 to-yellow-300 transition-all duration-700 ease-out shadow-[0_0_8px_rgba(255,255,255,0.7)] group-hover:animate-eqGlow"
-                style={{ height: `${neg}%` }}
+                className="absolute top-1/2 left-0 w-full h-px"
+                style={{ backgroundColor: color }}
               />
-              <div className="absolute top-1/2 left-0 w-full h-px bg-gray-600" />
             </div>
             <span className="mt-1 text-xs text-gray-400">{freq.replace('Hz', ' Hz')}</span>
           </div>
@@ -82,14 +79,14 @@ export default function PresetPage({ preset, data }) {
         className="w-48 h-48 mx-auto mb-6"
       />
       <h2 className="text-xl font-semibold mb-2">Signal chain</h2>
-      <ol className="space-y-4 mb-4">
+      <ol className="flex flex-col items-start space-y-4 mb-4">
         {data.chain.map((block, idx) => {
           const realName = deviceMappings[block.slot]?.[block.model];
           const color = slotColors[block.slot];
           return (
             <li
               key={idx}
-              className="relative p-4 rounded bg-gray-800 border-2"
+              className="relative p-4 rounded bg-gray-800 border-2 w-fit"
               style={{ borderColor: color }}
             >
               <div className="font-semibold mb-2">
@@ -97,7 +94,7 @@ export default function PresetPage({ preset, data }) {
                 {realName && <span className="text-gray-400"> — {realName}</span>}
               </div>
               {block.slot === 'EQ' ? (
-                <EqDisplay params={block.params} />
+                <EqDisplay params={block.params} color={color} />
               ) : (
                 <div className="flex flex-wrap gap-4">
                   {Object.entries(block.params).map(([key, value]) => (


### PR DESCRIPTION
## Summary
- Place knob value on new line to remove colon style
- Show EQ levels as color-coded markers with relative dB scale
- Let preset blocks size to content rather than full width

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68962c2090e8832a80932ccd67b56970