### PR TITLE
Refine knob labels and EQ display

### DIFF
--- a/components/Knob.js
+++ b/components/Knob.js
@@ -23,7 +23,9 @@ export default function Knob({ label, value, color = '#ef4444' }) {
         />
       </div>
       <span className="mt-2 text-xs text-gray-200 text-center">
-        {label}: {value}
+        {label}
+        <br />
+        {value}
       </span>
     </div>
   );

--- a/components/Toggle.js
+++ b/components/Toggle.js
@@ -1,0 +1,23 @@
+import React from 'react';
+
+export default function Toggle({ label, value, color = '#ef4444' }) {
+  const on = Boolean(value);
+  return (
+    <div className="flex flex-col items-center w-20">
+      <div
+        className="w-10 h-6 rounded-full flex items-center px-1"
+        style={{ backgroundColor: on ? color : '#4b5563' }}
+      >
+        <div
+          className="w-4 h-4 bg-gray-100 rounded-full transition-transform"
+          style={{ transform: on ? 'translateX(1rem)' : 'translateX(0)' }}
+        />
+      </div>
+      <span className="mt-2 text-xs text-gray-200 text-center">
+        {label}
+        <br />
+        {on ? 'On' : 'Off'}
+      </span>
+    </div>
+  );
+}

--- a/pages/preset/[id].js
+++ b/pages/preset/[id].js
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import Header from '../../components/Header';
 import Knob from '../../components/Knob';
+import Toggle from '../../components/Toggle';
 import { presets } from '../../data/presets';
 import { deviceMappings } from '../../data/deviceMappings';
 
@@ -26,14 +27,19 @@ function formatLabel(key) {
     .replace(/_/g, ' ');
 }
 
-function EqDisplay({ params }) {
+function EqDisplay({ params, color = '#9ca3af' }) {
   const freqs = Object.keys(params);
   const [levels, setLevels] = useState(
     freqs.reduce((acc, f) => ({ ...acc, [f]: 50 }), {})
   );
 
   useEffect(() => {
-    const timer = setTimeout(() => setLevels(params), 100);
+    const timer = setTimeout(
+      () => setLevels(Object.fromEntries(
+        Object.entries(params).map(([k, v]) => [k, Number(v)])
+      )),
+      100
+    );
     return () => clearTimeout(timer);
   }, [params]);
 
@@ -41,25 +47,26 @@ function EqDisplay({ params }) {
     <div className="flex items-center h-32 space-x-3 p-4 bg-gray-900 rounded-lg border border-gray-700">
       {freqs.map((freq) => {
         const val = Number(levels[freq]);
-        const pos = Math.max(0, val - 50) * 2;
-        const neg = Math.max(0, 50 - val) * 2;
-        const display = Number(params[freq]) - 50;
+        const display = ((val - 50) / 50) * 15;
         return (
           <div key={freq} className="flex flex-col items-center">
             <span className="mb-1 text-xs text-gray-200">
               {display >= 0 ? '+' : ''}
-              {display}
+              {display.toFixed(1)} dB
             </span>
-            <div className="relative w-4 h-28 bg-gray-800 rounded overflow-hidden group">
+            <div className="relative w-4 h-28 bg-gray-800 rounded overflow-hidden">
               <div
-                className="absolute bottom-1/2 w-full bg-gradient-to-t from-red-600 via-pink-500 to-yellow-300 transition-all duration-700 ease-out shadow-[0_0_8px_rgba(255,255,255,0.7)] group-hover:animate-eqGlow"
-                style={{ height: `${pos}%` }}
+                className="absolute left-0 w-full h-0.5"
+                style={{
+                  top: `${100 - val}%`,
+                  backgroundColor: color,
+                  transform: 'translateY(-50%)'
+                }}
               />
               <div
-                className="absolute top-1/2 w-full bg-gradient-to-b from-red-600 via-pink-500 to-yellow-300 transition-all duration-700 ease-out shadow-[0_0_8px_rgba(255,255,255,0.7)] group-hover:animate-eqGlow"
-                style={{ height: `${neg}%` }}
+                className="absolute top-1/2 left-0 w-full h-px"
+                style={{ backgroundColor: color }}
               />
-              <div className="absolute top-1/2 left-0 w-full h-px bg-gray-600" />
             </div>
             <span className="mt-1 text-xs text-gray-400">{freq.replace('Hz', ' Hz')}</span>
           </div>
@@ -82,14 +89,14 @@ export default function PresetPage({ preset, data }) {
         className="w-48 h-48 mx-auto mb-6"
       />
       <h2 className="text-xl font-semibold mb-2">Signal chain</h2>
-      <ol className="space-y-4 mb-4">
+      <ol className="flex items-start space-x-4 overflow-x-auto mb-4 pr-4">
         {data.chain.map((block, idx) => {
           const realName = deviceMappings[block.slot]?.[block.model];
           const color = slotColors[block.slot];
           return (
             <li
               key={idx}
-              className="relative p-4 rounded bg-gray-800 border-2"
+              className="relative pt-4 pb-8 pl-4 pr-4 rounded bg-gray-800 border-2 w-fit"
               style={{ borderColor: color }}
             >
               <div className="font-semibold mb-2">
@@ -97,16 +104,25 @@ export default function PresetPage({ preset, data }) {
                 {realName && <span className="text-gray-400"> — {realName}</span>}
               </div>
               {block.slot === 'EQ' ? (
-                <EqDisplay params={block.params} />
+                <EqDisplay params={block.params} color={color} />
               ) : (
                 <div className="flex flex-wrap gap-4">
                   {Object.entries(block.params).map(([key, value]) => (
-                    <Knob
-                      key={key}
-                      label={formatLabel(key)}
-                      value={Number(value)}
-                      color={color}
-                    />
+                    key.toLowerCase() === 'bright' ? (
+                      <Toggle
+                        key={key}
+                        label={formatLabel(key)}
+                        value={Number(value)}
+                        color={color}
+                      />
+                    ) : (
+                      <Knob
+                        key={key}
+                        label={formatLabel(key)}
+                        value={Number(value)}
+                        color={color}
+                      />
+                    )
                   ))}
                 </div>
               )}


### PR DESCRIPTION
## Summary
- Place knob value on new line to remove colon style
- Show EQ levels as color-coded markers with relative dB scale
- Let preset blocks size to content rather than full width
- Prevent slot badge overlap and correct EQ marker positioning
- Render Bright parameter as a toggle switch instead of a knob
- Arrange signal-chain blocks in a horizontal row with right padding

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68962c2090e8832a80932ccd67b56970