### PR TITLE
Add full parameter types starting with AmplifierParams

### DIFF
--- a/lib/core/blocks/amplifier.ts
+++ b/lib/core/blocks/amplifier.ts
@@ -65,10 +65,36 @@ const TYPES: Record<AmplifierType, number> = {
   [AmplifierType.UberHiGain]: 25,
 };
 
-export type AmplifierParams = ChainItem<
-  AmplifierType.JazzClean,
-  "Gain" | "Master" | "Bass" | "Middle" | "Treble" | "Bright"
->;
+export type AmplifierParams = 
+  | ChainItem<AmplifierType.JazzClean, "Gain" | "Master" | "Bass" | "Middle" | "Treble" | "Bright">
+  | ChainItem<AmplifierType.DeluxeRvb, "Gain" | "Master" | "Bass" | "Middle" | "Treble">
+  | ChainItem<AmplifierType.BassMate, "Gain" | "Master" | "Bass" | "Middle" | "Treble" | "Presence">
+  | ChainItem<AmplifierType.Tweedy, "Gain" | "Master" | "Tone">
+  | ChainItem<AmplifierType.Hiwire, "Gain" | "Master" | "Bass" | "Middle" | "Treble" | "Presence">
+  | ChainItem<AmplifierType.CaliCrunch, "Gain" | "Master" | "Bass" | "Middle" | "Treble" | "Presence">
+  | ChainItem<AmplifierType.ClassA15, "Gain" | "Master" | "Bass" | "Treble" | "Cut">
+  | ChainItem<AmplifierType.ClassA30, "Gain" | "Master" | "Bass" | "Treble" | "Cut">
+  | ChainItem<AmplifierType.Plexi100, "Gain" | "Master" | "Bass" | "Middle" | "Treble" | "Presence">
+  | ChainItem<AmplifierType.Plexi45, "Gain" | "Master" | "Bass" | "Middle" | "Treble" | "Presence">
+  | ChainItem<AmplifierType.Brit800, "Gain" | "Master" | "Bass" | "Middle" | "Treble" | "Presence">
+  | ChainItem<AmplifierType.Amp1987X50, "Gain" | "Master" | "Bass" | "Middle" | "Treble" | "Presence">
+  | ChainItem<AmplifierType.Slo100, "Gain" | "Master" | "Bass" | "Middle" | "Treble" | "Presence">
+  | ChainItem<AmplifierType.FiremanHbe, "Gain" | "Master" | "Bass" | "Middle" | "Treble" | "Presence">
+  | ChainItem<AmplifierType.DualRect, "Gain" | "Master" | "Bass" | "Middle" | "Treble" | "Presence">
+  | ChainItem<AmplifierType.DieVh4, "Gain" | "Master" | "Bass" | "Middle" | "Treble" | "Presence">
+  | ChainItem<AmplifierType.MrZ38, "Gain" | "Master" | "Bass" | "Treble" | "Cut">
+  | ChainItem<AmplifierType.SuperRvb, "Gain" | "Master" | "Bass" | "Middle" | "Treble" | "Bright">
+  | ChainItem<AmplifierType.Agl, "Gain" | "Master" | "Bass" | "Mid Freq" | "Middle" | "Treble">
+  | ChainItem<AmplifierType.Mld, "Gain" | "Master" | "Bass" | "Mid Freq" | "Middle" | "Treble">
+  | ChainItem<AmplifierType.OptimaAir, "Gain" | "Master" | "Bass" | "Middle" | "Treble">
+  | ChainItem<AmplifierType.Stageman, "Gain" | "Master" | "Bass" | "Middle" | "Treble">
+  | ChainItem<AmplifierType.TwinReverb, "Gain" | "Master" | "Bass" | "Middle" | "Treble" | "Bright">
+  | ChainItem<AmplifierType.VibroKing, "Gain" | "Master" | "Bass" | "Middle" | "Treble" | "Bright">
+  | ChainItem<AmplifierType.Budda, "Gain" | "Master" | "Bass" | "Treble" | "Cut">
+  | ChainItem<AmplifierType.BritBlues, "Gain" | "Master" | "Bass" | "Middle" | "Treble" | "Presence">
+  | ChainItem<AmplifierType.MatchD30, "Gain" | "Master" | "Bass" | "Treble" | "Cut">
+  | ChainItem<AmplifierType.Brit2000, "Gain" | "Master" | "Bass" | "Middle" | "Treble" | "Presence">
+  | ChainItem<AmplifierType.UberHiGain, "Gain" | "Master" | "Bass" | "Middle" | "Treble" | "Presence">;
 
 export const amplifier: BlockConfig = {
   encoderHeadIndex: NuxMp3PresetIndex.Head_iAMP,

--- a/lib/core/blocks/cabinet.ts
+++ b/lib/core/blocks/cabinet.ts
@@ -74,10 +74,41 @@ const TYPES: Record<CabinetType, number> = {
   [CabinetType.M_D45]: 34,
 };
 
-export type CabinetParams = ChainItem<
-  CabinetType.JZ120,
-  "Level" | "LowCut" | "HighCut"
->;
+export type CabinetParams = 
+  | ChainItem<CabinetType.JZ120, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.DR112, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.TR212, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.HIWIRE412, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.CALI112, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.A112, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.GB412, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.M1960AX, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.M1960AV, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.M1960TV, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.SLO412, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.FIREMAN412, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.RECT412, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.DIE412, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.MATCH212, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.UBER412, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.BS410, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.A212, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.M1960AHW, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.M1936, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.BUDDA112, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.Z212, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.SUPERVERB410, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.VIBROKING310, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.AGL_DB810, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.AMP_SV212, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.AMP_SV410, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.AMP_SV810, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.BASSGUY410, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.EDEN410, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.MKB410, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.G_HBIRD, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.G_J15, "Level" | "LowCut" | "HighCut">
+  | ChainItem<CabinetType.M_D45, "Level" | "LowCut" | "HighCut">;
 
 const cabParams: TypeParamConfig[] = [
   {

--- a/lib/core/blocks/delay.ts
+++ b/lib/core/blocks/delay.ts
@@ -19,10 +19,13 @@ const TYPES: Record<DelayType, number> = {
   [DelayType.PhiDelay]: 6,
 };
 
-export type DelayParams = ChainItem<
-  DelayType.AnalogDelay,
-  "Intensity" | "Rate" | "Echo"
->;
+export type DelayParams = 
+  | ChainItem<DelayType.AnalogDelay, "Intensity" | "Rate" | "Echo">
+  | ChainItem<DelayType.DigitalDelay, "E.Level" | "Feedback" | "Time">
+  | ChainItem<DelayType.ModDelay, "Level" | "Time" | "Repeat" | "Mod">
+  | ChainItem<DelayType.TapeEcho, "Level" | "Time" | "Repeat">
+  | ChainItem<DelayType.PanDelay, "Level" | "Time" | "Repeat">
+  | ChainItem<DelayType.PhiDelay, "Time" | "Repeat" | "Mix">;
 
 export const delay: BlockConfig = {
   encoderHeadIndex: NuxMp3PresetIndex.Head_iDLY,

--- a/lib/core/blocks/effect.ts
+++ b/lib/core/blocks/effect.ts
@@ -18,10 +18,21 @@ export enum EffectType {
   TouchWah = "Touch Wah",
 }
 
-export type EffectParams = ChainItem<
-  EffectType.DistortionPlus,
-  "Output" | "Sensitivity"
->;
+export type EffectParams = 
+  | ChainItem<EffectType.DistortionPlus, "Output" | "Sensitivity">
+  | ChainItem<EffectType.RCBoost, "Volume" | "Gain" | "Bass" | "Treble">
+  | ChainItem<EffectType.ACBoost, "Volume" | "Gain" | "Bass" | "Treble">
+  | ChainItem<EffectType.DistOne, "Level" | "Drive" | "Tone">
+  | ChainItem<EffectType.TScreamer, "Level" | "Drive" | "Tone">
+  | ChainItem<EffectType.BluesDrive, "Level" | "Gain" | "Tone">
+  | ChainItem<EffectType.MorningDrive, "Volume" | "Drive" | "Tone">
+  | ChainItem<EffectType.EatDist, "Volume" | "Distortion" | "Filter">
+  | ChainItem<EffectType.RedDirt, "Level" | "Drive" | "Tone">
+  | ChainItem<EffectType.Crunch, "Volume" | "Gain" | "Tone">
+  | ChainItem<EffectType.MuffFuzz, "Volume" | "Sustain" | "Tone">
+  | ChainItem<EffectType.Katana, "Volume" | "Boost">
+  | ChainItem<EffectType.STSinger, "Volume" | "Gain" | "Filter">
+  | ChainItem<EffectType.TouchWah, "Type" | "Wow" | "Sense" | "Level" | "Up/Down Switch">;
 
 const TYPES: Record<EffectType, number> = {
   [EffectType.DistortionPlus]: 1,

--- a/lib/core/blocks/modulation.ts
+++ b/lib/core/blocks/modulation.ts
@@ -18,10 +18,21 @@ export enum ModulationType {
   MonoOctave = "Mono Octave",
 }
 
-export type ModulationParams = ChainItem<
-  ModulationType.CE1,
-  "Rate" | "Depth" | "Intensity"
->;
+export type ModulationParams = 
+  | ChainItem<ModulationType.CE1, "Rate" | "Depth" | "Intensity">
+  | ChainItem<ModulationType.CE2, "Rate" | "Depth">
+  | ChainItem<ModulationType.STChorus, "Rate" | "Width" | "Intensity">
+  | ChainItem<ModulationType.Vibrato, "Rate" | "Depth">
+  | ChainItem<ModulationType.Detune, "Shift-L" | "Shift-R" | "Mix">
+  | ChainItem<ModulationType.Flanger, "Rate" | "Width" | "Level" | "Feedback">
+  | ChainItem<ModulationType.Phase90, "Speed">
+  | ChainItem<ModulationType.Phase100, "Speed" | "Intensity">
+  | ChainItem<ModulationType.SCF, "Speed" | "Width" | "Intensity" | "Mode">
+  | ChainItem<ModulationType.UVibe, "Speed" | "Volume" | "Intensity" | "Mode">
+  | ChainItem<ModulationType.Tremolo, "Rate" | "Depth">
+  | ChainItem<ModulationType.Rotary, "Speed" | "Balance">
+  | ChainItem<ModulationType.SCH1, "Rate" | "Depth" | "Tone">
+  | ChainItem<ModulationType.MonoOctave, "Sub" | "Dry" | "Up">;
 
 const TYPES: Record<ModulationType, number> = {
   [ModulationType.CE1]: 1,

--- a/lib/core/decoder.test.ts
+++ b/lib/core/decoder.test.ts
@@ -29,7 +29,7 @@ describe("decoder", () => {
     const encoded = encodeChain(chain);
     const bytes = new Uint8Array(encoded.bytes);
     bytes[0] = 0; // Неправильный ID продукта
-    const invalidQr = "nux://MightyAmp:" + btoa(String.fromCharCode(...bytes));
+    const invalidQr = "nux://MightyAmp:" + btoa(String.fromCharCode(...Array.from(bytes)));
 
     expect(() => decodeChain(invalidQr)).toThrow(
       "Invalid product ID or version"

--- a/lib/core/decoder.ts
+++ b/lib/core/decoder.ts
@@ -89,12 +89,10 @@ export const decodeChain = (qrCode: string): Chain => {
       }
 
       // Добавляем блок в цепочку
-      chain[blockType] = {
-        // @ts-expect-error - undefined is not a string
+      // Используем any для обхода проблемы со сложными union типами
+      (chain as any)[blockType] = {
         type: typeConfig.label,
-        // @ts-expect-error - undefined is not a boolean
         enabled,
-        // @ts-expect-error - undefined is not a Record<string, number>
         params,
       };
     }

--- a/lib/core/encoder.test.ts
+++ b/lib/core/encoder.test.ts
@@ -82,7 +82,10 @@ describe("Core Encoder Tests", () => {
       const chain2 = createDefaultChain();
 
       // Изменяем один из чейнов
-      chain2.amplifier.params.Bass = 99;
+      // Проверяем что это JazzClean тип (по умолчанию)
+      if (chain2.amplifier.type === "Jazz Clean") {
+        chain2.amplifier.params.Bass = 99;
+      }
       chain2.effect.enabled = false;
 
       const encoded1 = encodeChain(chain1);


### PR DESCRIPTION
Add comprehensive type definitions for block parameters to enhance type safety and IDE autocompletion.

The updated parameter types, now represented as union types, necessitated minor adjustments in `decoder.ts` for handling complex type assignments and in `encoder.test.ts` to ensure correct access to type-specific parameters.

---
<a href="https://cursor.com/background-agent?bcId=bc-3a17b1ce-6b71-406a-bc7f-4c069fa4c6e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3a17b1ce-6b71-406a-bc7f-4c069fa4c6e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

