### PR TITLE
Починить билд и линтер

### DIFF
--- a/lib/core/decoder.test.ts
+++ b/lib/core/decoder.test.ts
@@ -29,7 +29,7 @@ describe("decoder", () => {
     const encoded = encodeChain(chain);
     const bytes = new Uint8Array(encoded.bytes);
     bytes[0] = 0; // Неправильный ID продукта
-    const invalidQr = "nux://MightyAmp:" + btoa(String.fromCharCode(...bytes));
+    const invalidQr = "nux://MightyAmp:" + btoa(String.fromCharCode.apply(null, Array.from(bytes)));
 
     expect(() => decodeChain(invalidQr)).toThrow(
       "Invalid product ID or version"

--- a/lib/core/decoder.ts
+++ b/lib/core/decoder.ts
@@ -84,17 +84,15 @@ export const decodeChain = (qrCode: string): Chain => {
       // Создаем объект с параметрами
       const params = {} as Record<string, number>;
       for (const param of typeConfig.params) {
-        // @ts-expect-error - undefined is not a number
-        params[param.label] = data[param.encodeIndex];
+        params[param.label] = data[param.encodeIndex] ?? 0;
       }
 
       // Добавляем блок в цепочку
-      chain[blockType] = {
-        // @ts-expect-error - undefined is not a string
+      // Use type assertion to avoid union type complexity
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+      (chain as any)[blockType] = {
         type: typeConfig.label,
-        // @ts-expect-error - undefined is not a boolean
         enabled,
-        // @ts-expect-error - undefined is not a Record<string, number>
         params,
       };
     }

--- a/lib/core/encoder.test.ts
+++ b/lib/core/encoder.test.ts
@@ -82,7 +82,10 @@ describe("Core Encoder Tests", () => {
       const chain2 = createDefaultChain();
 
       // Изменяем один из чейнов
-      chain2.amplifier.params.Bass = 99;
+      // Type guard to ensure we're working with JazzClean amplifier
+      if ('Bass' in chain2.amplifier.params) {
+        chain2.amplifier.params.Bass = 99;
+      }
       chain2.effect.enabled = false;
 
       const encoded1 = encodeChain(chain1);


### PR DESCRIPTION
Fix build and linter errors by resolving a TypeScript complex union type issue and undefined access.

The TypeScript compiler was unable to infer a manageable type for `chain[blockType]` because `blockType` is dynamic and the assigned values (e.g., `AmplifierParams`, `CabinetParams`) are themselves complex union types. Using a type assertion `(chain as any)[blockType]` simplifies this for the compiler. Additionally, a nullish coalescing operator was added to handle potential `undefined` values from `data[param.encodeIndex]`.

---
<a href="https://cursor.com/background-agent?bcId=bc-420d24af-c6a8-4c62-b99e-cda94a2ed58a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-420d24af-c6a8-4c62-b99e-cda94a2ed58a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

